### PR TITLE
Remove turbolinks to fix jquery issue with post activation button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap
-//= require turbolinks
 //= require d3
 //= require_tree .
 
@@ -239,6 +238,7 @@ $(document).ready(function(){
     $(id).show();
   });
 
+
 // post deactivate button
    $(document).on("click", '#activation', function(event){
     event.preventDefault();
@@ -268,5 +268,4 @@ $(document).ready(function(){
       $("#active-icon i").addClass(activeIconId);
     });
   });
-
 });


### PR DESCRIPTION
@andarcabrera  I figured out how to fix the problem where we had to reload the page to deactivate a post! Turbolinks was the culprit. I guess it speeds up the page load-time so some of the JavaScript/jQuery doesn't have time to load before we call "$(document).ready". Going to do some more research on turbolinks next week, but everything else seems to be working fine without it!
